### PR TITLE
Use outline to build trip plan

### DIFF
--- a/app/client/src/App.tsx
+++ b/app/client/src/App.tsx
@@ -15,7 +15,9 @@ function AppRoutes() {
           path="/"
           element={
             <PickAdventure
-              onPick={(card) => navigate(`/recommend`, { state: { card } })}
+              onPick={(card, startTime, duration) =>
+                navigate(`/recommend`, { state: { card, startTime, duration } })
+              }
             />
           }
         />

--- a/app/client/src/components/PickAdventure.tsx
+++ b/app/client/src/components/PickAdventure.tsx
@@ -8,10 +8,11 @@ import PickAdventureForm, { Address } from "./PickAdventureForm";
 export default function PickAdventure({
   onPick
 }: {
-  onPick: (card: Adventure) => void;
+  onPick: (card: Adventure, startTime: string, duration: number) => void;
 }) {
   const [cards, setCards] = useState<Adventure[]>([]);
   const [address, setAddress] = useState<Address>({ lat: null, lng: null, streetAddress: "" });
+  const [startTime, setStartTime] = useState<string>("09:00");
   const [duration, setDuration] = useState<number>(5);
   const [showCards, setShowCards] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -68,13 +69,15 @@ export default function PickAdventure({
       <PickAdventureForm
         address={address}
         setAddress={setAddress}
+        startTime={startTime}
+        setStartTime={setStartTime}
         duration={duration}
         setDuration={setDuration}
         loading={loading}
         onProceed={handleProceed}
       />
       {showCards && (
-        <PickAdventureCards cards={cards} onPick={onPick} />
+        <PickAdventureCards cards={cards} onPick={(c) => onPick(c, startTime, duration)} />
       )}
     </CenteredLayout>
   );

--- a/app/client/src/components/PickAdventure.tsx
+++ b/app/client/src/components/PickAdventure.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { AdventureCard } from "../types";
+import { Adventure } from "../types";
 import CenteredLayout from "./CenteredLayout";
 import PickAdventureCards from "./PickAdventureCards";
 import PickAdventureForm, { Address } from "./PickAdventureForm";
@@ -8,9 +8,9 @@ import PickAdventureForm, { Address } from "./PickAdventureForm";
 export default function PickAdventure({
   onPick
 }: {
-  onPick: (card: AdventureCard) => void;
+  onPick: (card: Adventure) => void;
 }) {
-  const [cards, setCards] = useState<AdventureCard[]>([]);
+  const [cards, setCards] = useState<Adventure[]>([]);
   const [address, setAddress] = useState<Address>({ lat: null, lng: null, streetAddress: "" });
   const [duration, setDuration] = useState<number>(5);
   const [showCards, setShowCards] = useState(false);
@@ -53,6 +53,9 @@ export default function PickAdventure({
     }
     axios.get(url)
       .then((res) => res.data)
+      .then((list: Adventure[]) =>
+        list.map((adv, i) => ({ ...adv, id: adv.id || String(i) }))
+      )
       .then(setCards)
       .finally(() => {
         setShowCards(true);

--- a/app/client/src/components/PickAdventureCards.tsx
+++ b/app/client/src/components/PickAdventureCards.tsx
@@ -1,30 +1,36 @@
-import { AdventureCard } from "../types";
+import { Adventure } from "../types";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card";
 
 export interface PickAdventureCardsProps {
-  cards: AdventureCard[];
-  onPick: (card: AdventureCard) => void;
+  cards: Adventure[];
+  onPick: (card: Adventure) => void;
 }
 
 export default function PickAdventureCards({ cards, onPick }: PickAdventureCardsProps) {
   return (
     <div id="pick-adventure-cards" className="flex-1 flex flex-wrap justify-center items-center gap-24 w-full">
-      {cards.map((c) => (
-        <Card
-          key={c.id}
-          className="cursor-pointer w-full max-w-xs"
-          onClick={() => onPick(c)}
-          id={`pick-adventure-card-${c.id}`}
-        >
+      {cards.map((c) => {
+        const subtitle = c.outline
+          .map((o) => o.name)
+          .slice(0, 2)
+          .join(" + ");
+        return (
+          <Card
+            key={c.id}
+            className="cursor-pointer w-full max-w-xs"
+            onClick={() => onPick(c)}
+            id={`pick-adventure-card-${c.id}`}
+          >
           <CardHeader id={`pick-adventure-card-header-${c.id}`}>
             <CardTitle id={`pick-adventure-card-title-${c.id}`}>{c.title}</CardTitle>
           </CardHeader>
           <CardContent className="justify-between p-4" id={`pick-adventure-card-content-${c.id}`}>
             <img src={c.heroImage} alt={c.title} className="w-full aspect-square object-cover rounded-t-xl" id={`pick-adventure-card-img-${c.id}`}/>
-            <CardDescription id={`pick-adventure-card-desc-${c.id}`}>{c.subtitle}</CardDescription>
+            <CardDescription id={`pick-adventure-card-desc-${c.id}`}>{subtitle}</CardDescription>
           </CardContent>
-        </Card>
-      ))}
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/app/client/src/components/PickAdventureForm.tsx
+++ b/app/client/src/components/PickAdventureForm.tsx
@@ -8,6 +8,8 @@ export type Address = {
 export interface PickAdventureFormProps {
   address: Address;
   setAddress: (a: Address) => void;
+  startTime: string;
+  setStartTime: (v: string) => void;
   duration: number;
   setDuration: (v: number) => void;
   loading: boolean;
@@ -15,7 +17,7 @@ export interface PickAdventureFormProps {
 }
 
 export default function PickAdventureForm(props: PickAdventureFormProps) {
-  const { address, setAddress, duration, setDuration, loading, onProceed } = props;
+  const { address, setAddress, startTime, setStartTime, duration, setDuration, loading, onProceed } = props;
   // Handle address input change and parse lat,lng if present
   const handleAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
@@ -45,6 +47,16 @@ export default function PickAdventureForm(props: PickAdventureFormProps) {
             onChange={handleAddressChange}
             placeholder="lat,lng or address"
             title={address.streetAddress}
+          />
+        </div>
+        <div className="flex flex-col">
+          <label htmlFor="start-time" className="text-xs font-semibold mb-1">Start Time</label>
+          <input
+            id="start-time"
+            type="time"
+            className="border rounded px-2 py-1 w-24"
+            value={startTime}
+            onChange={e => setStartTime(e.target.value)}
           />
         </div>
         <div className="flex flex-col">

--- a/app/client/src/components/RecommendedTrip.tsx
+++ b/app/client/src/components/RecommendedTrip.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
-import { AdventureCard, TripPlan } from "../types";
+import { Adventure, TripPlan } from "../types";
+import { createTripPlan } from "../lib/createTripPlan";
 import CenteredLayout from "./CenteredLayout";
 
 export default function RecommendedTrip({
@@ -9,8 +9,8 @@ export default function RecommendedTrip({
   onChoose,
   onFineTune
 }: {
-  card: AdventureCard;
-  onRefresh: (c: AdventureCard) => void;
+  card: Adventure;
+  onRefresh: (c: Adventure) => void;
   onChoose: (trip: TripPlan) => void;
   onFineTune: (trip: TripPlan) => void;
 }) {
@@ -18,13 +18,8 @@ export default function RecommendedTrip({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setLoading(true);
-    axios.post("/api/recommendation", { themeId: card.id })
-      .then((res) => res.data)
-      .then((p) => {
-        setPlan(p);
-        setLoading(false);
-      });
+    setPlan(createTripPlan(card));
+    setLoading(false);
   }, [card]);
 
   if (loading || !plan) return <p>Loading recommendation…</p>;
@@ -46,11 +41,7 @@ export default function RecommendedTrip({
         <div id="recommended-trip-buttons" className="grid grid-cols-3 gap-2 mt-20">
           <button id="recommended-trip-refresh-btn"
             className="bg-gray-200 rounded-xl py-2 text-sm"
-            onClick={() =>
-              axios.post("/api/refresh", { themeId: card.id })
-                .then((res) => res.data)
-                .then(onRefresh)
-            }
+            onClick={() => onRefresh(card)}
           >
             Refresh
           </button>

--- a/app/client/src/components/RecommendedTrip.tsx
+++ b/app/client/src/components/RecommendedTrip.tsx
@@ -5,11 +5,15 @@ import CenteredLayout from "./CenteredLayout";
 
 export default function RecommendedTrip({
   card,
+  startTime,
+  duration,
   onRefresh,
   onChoose,
   onFineTune
 }: {
   card: Adventure;
+  startTime: string;
+  duration: number;
   onRefresh: (c: Adventure) => void;
   onChoose: (trip: TripPlan) => void;
   onFineTune: (trip: TripPlan) => void;
@@ -18,9 +22,9 @@ export default function RecommendedTrip({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setPlan(createTripPlan(card));
+    setPlan(createTripPlan(card, duration, startTime));
     setLoading(false);
-  }, [card]);
+  }, [card, duration, startTime]);
 
   if (loading || !plan) return <p>Loading recommendation…</p>;
 

--- a/app/client/src/lib/createTripPlan.ts
+++ b/app/client/src/lib/createTripPlan.ts
@@ -10,9 +10,10 @@ function minutesToTime(min: number): string {
   return `${h}:${m}`;
 }
 
-export function createTripPlan(adventure: Adventure): TripPlan {
-  const start = 9 * 60;
-  const end = 17 * 60;
+export function createTripPlan(adventure: Adventure, hours: number, startStr = "09:00"): TripPlan {
+  const [sh, sm] = startStr.split(":").map((s) => parseInt(s, 10));
+  const start = (sh || 0) * 60 + (sm || 0);
+  const end = start + hours * 60;
   const available = end - start;
   const total = adventure.outline.reduce((t, o) => t + o.durationMin, 0) || 1;
   const scale = available / total;

--- a/app/client/src/lib/createTripPlan.ts
+++ b/app/client/src/lib/createTripPlan.ts
@@ -1,0 +1,32 @@
+import { Adventure, TripPlan } from "../types";
+
+function minutesToTime(min: number): string {
+  const h = Math.floor(min / 60)
+    .toString()
+    .padStart(2, "0");
+  const m = Math.round(min % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+export function createTripPlan(adventure: Adventure): TripPlan {
+  const start = 9 * 60;
+  const end = 17 * 60;
+  const available = end - start;
+  const total = adventure.outline.reduce((t, o) => t + o.durationMin, 0) || 1;
+  const scale = available / total;
+
+  let current = start;
+  const legs = adventure.outline.map((item) => {
+    const time = minutesToTime(current);
+    current += item.durationMin * scale;
+    return { time, label: item.name, notes: item.startHint };
+  });
+
+  return {
+    theme: adventure.title,
+    legs,
+    packing: [],
+  };
+}

--- a/app/client/src/routes/RecommendRoute.tsx
+++ b/app/client/src/routes/RecommendRoute.tsx
@@ -8,6 +8,8 @@ export default function RecommendRoute() {
   const { adventureId } = useParams();
   const location = useLocation();
   const cardFromState = location.state?.card as Adventure | undefined;
+  const startTime = location.state?.startTime as string | undefined;
+  const duration = location.state?.duration as number | undefined;
   const navigate = useNavigate();
   const [adventure, setAdventure] = useState<Adventure | null>(cardFromState || null);
 
@@ -22,9 +24,19 @@ export default function RecommendRoute() {
   return (
     <RecommendedTrip
       card={adventure}
-      onRefresh={(newCard) => navigate(`/recommend/${newCard.id}`, { state: { card: newCard } })}
-      onChoose={(trip) => navigate(`/plan/${adventure.id}`, { state: { plan: trip } })}
-      onFineTune={(trip) => navigate(`/plan/${adventure.id}/edit`, { state: { plan: trip } })}
+      startTime={startTime ?? "09:00"}
+      duration={duration ?? 8}
+      onRefresh={(newCard) =>
+        navigate(`/recommend/${newCard.id}`, {
+          state: { card: newCard, startTime: startTime ?? "09:00", duration: duration ?? 8 }
+        })
+      }
+      onChoose={(trip) =>
+        navigate(`/plan/${adventure.id}`, { state: { plan: trip } })
+      }
+      onFineTune={(trip) =>
+        navigate(`/plan/${adventure.id}/edit`, { state: { plan: trip } })
+      }
     />
   );
 }

--- a/app/client/src/routes/RecommendRoute.tsx
+++ b/app/client/src/routes/RecommendRoute.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import RecommendedTrip from "../components/RecommendedTrip";
-import { AdventureCard } from "../types";
+import { Adventure } from "../types";
 import Redirect from "./Redirect";
 
 export default function RecommendRoute() {
   const { adventureId } = useParams();
   const location = useLocation();
-  const cardFromState = location.state?.card as AdventureCard | undefined;
+  const cardFromState = location.state?.card as Adventure | undefined;
   const navigate = useNavigate();
-  const [adventure, setAdventure] = useState<AdventureCard | null>(cardFromState || null);
+  const [adventure, setAdventure] = useState<Adventure | null>(cardFromState || null);
 
   useEffect(() => {
     if (!cardFromState) return;

--- a/app/client/src/types.ts
+++ b/app/client/src/types.ts
@@ -1,9 +1,15 @@
-export interface AdventureCard {
+export interface Adventure {
   id: string;
   title: string;
-  subtitle: string;
   heroImage: string;
+  driveTimeMin: number;
+  outline: { name: string; startHint: string; durationMin: number }[];
+  tags: string[];
+  costUSD: string;
+  sources: { title: string; url: string }[];
 }
+
+export type AdventureCard = Adventure;
 
 export interface TripPlan {
   theme: string;


### PR DESCRIPTION
## Summary
- extend `Adventure` type to match server payload
- generate trip plan client-side from adventure outline
- compute simple subtitles for adventure cards
- keep selections with React Router state

## Testing
- `npx tsc -p app/client/tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684469401c60832cad8495d8cb237cdb