### PR TITLE
Add Azure deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ The server expects the following variables to be set via a `.env` file or the en
 During development you can run the client and server separately using their respective `dev` or `start` scripts.
 
 This project requires **Node.js 20** or later.
+
+## Deployment
+Two helper scripts automate deployment to Azure:
+
+```bash
+./scripts/deploy-client.sh # Deploys the client to Azure Static Web Apps
+./scripts/deploy-server.sh # Deploys the server to Azure App Service
+```
+
+The scripts expect the following environment variables:
+
+- `AZURE_RESOURCE_GROUP` – resource group containing your Azure resources
+- `AZURE_STATIC_WEB_APP_NAME` – name of the Static Web App for the client
+- `AZURE_APP_SERVICE_NAME` – name of the App Service for the server
+
+Ensure the Azure CLI is installed and you are logged in before running them.

--- a/scripts/deploy-client.sh
+++ b/scripts/deploy-client.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the client application
+npm run build --prefix app/client
+
+# Deploy to Azure Static Web App
+: "${AZURE_STATIC_WEB_APP_NAME?}"  # Name of the Static Web App
+: "${AZURE_RESOURCE_GROUP?}"       # Resource group containing the Static Web App
+
+az staticwebapp upload \
+  --name "$AZURE_STATIC_WEB_APP_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --source app/client/dist/client

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the server application
+npm run build --prefix app/server
+
+# Install production dependencies
+npm install --prefix app/server --production
+
+# Package build output for deployment
+pushd app/server > /dev/null
+zip -r ../server.zip dist package.json package-lock.json node_modules >/dev/null
+popd > /dev/null
+
+# Deploy to Azure App Service
+: "${AZURE_APP_SERVICE_NAME?}"   # Name of the App Service
+: "${AZURE_RESOURCE_GROUP?}"     # Resource group containing the App Service
+
+az webapp deployment source config-zip \
+  --name "$AZURE_APP_SERVICE_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --src server.zip
+
+# Clean up
+rm server.zip


### PR DESCRIPTION
## Summary
- add shell scripts to deploy the client to Azure Static Web Apps and the server to Azure App Service
- document new deployment workflow in the README

## Testing
- `npm install --prefix app/server`
- `npm run build --prefix app/server`
- `npm install --prefix app/client`
- `npm run build --prefix app/client` *(fails: Rollup failed to resolve 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_68491fef9504832c85173cc25784d713